### PR TITLE
Don't eval into the module during precompilation

### DIFF
--- a/src/PyMNE.jl
+++ b/src/PyMNE.jl
@@ -28,6 +28,8 @@ function __init__()
     # all of this is __init__() so that it plays nice with precompilation
     # see https://github.com/JuliaPy/PyCall.jl/#using-pycall-from-julia-modules
     copy!(mne, pyimport("mne"))
+    # don't eval into the module while precompiling; this breaks precompilation
+    # of downstream modules (see #4)
     if ccall(:jl_generating_output, Cint, ()) == 0
         # delegate everything else to mne
         for pn in propertynames(mne)

--- a/src/PyMNE.jl
+++ b/src/PyMNE.jl
@@ -28,11 +28,13 @@ function __init__()
     # all of this is __init__() so that it plays nice with precompilation
     # see https://github.com/JuliaPy/PyCall.jl/#using-pycall-from-julia-modules
     copy!(mne, pyimport("mne"))
-    # delegate everything else to mne
-    for pn in propertynames(mne)
-        isdefined(@__MODULE__, pn) && continue
-        prop = getproperty(mne, pn)
-        @eval $pn = $prop
+    if ccall(:jl_generating_output, Cint, ()) == 0
+        # delegate everything else to mne
+        for pn in propertynames(mne)
+            isdefined(@__MODULE__, pn) && continue
+            prop = getproperty(mne, pn)
+            @eval $pn = $prop
+        end
     end
     return nothing
 end


### PR DESCRIPTION
This avoids evaluating the symbols from MNE while Julia is precompiling. Seems to fix #4. Closes #5.