### PR TITLE
Update Code Coverage in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-uploadcodecov@v0.1
-        if:  ${{ startsWith(matrix.os, 'ubuntu') && (matrix.version == '1') }}
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v2
+        with:
+          file: lcov.info


### PR DESCRIPTION
PR to update the Code Coverage step. The previous step `julia-action/julia-uploadcodecov` was deprecated.

Deprecation notice found in: https://github.com/julia-actions/julia-uploadcodecov

Recommendation found in that notice is to use [`julia-actions/julia-processcoverage`](https://github.com/julia-actions/julia-processcoverage) in combination with [`codecov/codecov-action`](https://github.com/codecov/codecov-action)

The README.md in https://github.com/julia-actions/julia-processcoverage contains example usage and is what is used in this PR

- [x] Assuming tests run properly and pass then this should be ready to review