### PR TITLE
remove anaconda from sources and move back to using conda for install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+Manifest-v*.toml
 
 .CondaPkg/
 coverage/lcov.info

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,14 +1,11 @@
-channels = ["anaconda", "conda-forge"]
+channels = ["conda-forge"]
 
 [deps]
 # Conda package names and versions
 python = ">=3.4,<4"
 # see https://mne.tools/stable/install/manual_install.html#installing-mne-python-with-all-dependencies
 # CondaPkg uses mamba by default
-# currently broken when using conda deps
-# xref: https://github.com/beacon-biosignals/PyMNE.jl/issues/17
-# xref: https://github.com/cjdoris/PythonCall.jl/issues/315
-# mne = ">=1.4"
+mne = ">=1.4, <2"
 
 [pip.deps]
-mne = ">=1.4"
+# mne = ">=1.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PyMNE"
 uuid = "6c5003b2-cbe8-491c-a0d1-70088e6a0fd6"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"


### PR DESCRIPTION
* Having both anaconda and conda-forge as sources can led to some difficulty to debug dependency issues and is not recommended.
* The previous issues on Apple Silicon have been addressed somewhere upstream, so we can go back to conda-based installation and drop the pip installation path.