### PR TITLE
zizmor audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,8 +8,12 @@ jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
     steps:
-      - uses: JuliaRegistries/TagBot@v1
+      - uses: JuliaRegistries/TagBot@6b7c22e7bc2b8f4d1c56b7199a63421cf2667ed1 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/YASG.yml
+++ b/.github/workflows/YASG.yml
@@ -18,19 +18,24 @@ jobs:
     # Run on push's or non-draft PRs
     if: (github.event_name == 'push') || (github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         julia-version: [1.7]
     steps:
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32  # v3.0.2
         with:
           version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Instantiate `format` environment and format
         run: |
           julia --project=format -e 'using Pkg; Pkg.instantiate()'
           julia --project=format 'format/run.jl'
-      - uses: reviewdog/action-suggester@v1
+      - uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
         if: github.event_name == 'pull_request'
         with:
           tool_name: JuliaFormatter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -29,15 +31,17 @@ jobs:
           - macOS-latest
           - windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2
         with:
           version: ${{ matrix.version }}
           show-versioninfo: 'false'
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1
+      - uses: julia-actions/julia-runtest@d60b785c6f2bdf4ebfb18b2b6f7d93b7dfb0efe3 # v1
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           files: lcov.info

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,28 @@
+---
+name: GitHub Actions Security Analysis with zizmor 🌈
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
+permissions: {}
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      # security-events: write  # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+      contents: read  # Only needed for private repos. Needed to clone the repo.
+      # actions: read  # Only needed for private repos. Needed for upload-sarif to read workflow run info.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
| Workflow | Job | Permissions Before | Permissions After | Rationale |
|---|---|---|---|---|
| CompatHelper.yml | CompatHelper | none (default) | `contents: write`, `pull-requests: write` | CompatHelper pushes commits and opens PRs to bump compat bounds |
| TagBot.yml | TagBot | none (default) | `contents: write`, `issues: read`, `pull-requests: read` | TagBot creates tags/releases; triggered by `issue_comment` so needs issues read |
| YASG.yml | format-check | none (default) | `contents: read`, `pull-requests: write` | Reads code to check formatting; reviewdog action-suggester posts inline PR review suggestions |
| ci.yml | test | none (default) | `contents: read` | Read-only: checkout, build, test, upload coverage |
| zizmor.yaml | zizmor | — (new file) | `contents: read` | Read-only: clones repo for zizmor analysis |
